### PR TITLE
fix: fix import in KeyboardAwareScrollView example

### DIFF
--- a/packages/keyboard-aware-scrollview/README.md
+++ b/packages/keyboard-aware-scrollview/README.md
@@ -68,7 +68,7 @@ Just pass `renderScrollComponent` props to list like below in example.
 ```jsx
 import React, { useCallback } from 'react';
 
-import KeyboardAwareScrollView from '@pietile-native-kit/keyboard-aware-scrollview';
+import { KeyboardAwareScrollView } from '@pietile-native-kit/keyboard-aware-scrollview';
 import { FlatList } from 'react-native';
 
 const ScrollComponent = React.forwardRef((forwardedProps, ref) => (


### PR DESCRIPTION
fixes the incorrect import in the `How to use with FlatList or SectionList?` example for KeyboardAwareScrollView